### PR TITLE
Add word-of-the-day feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "add-page": "node scripts/add-page.js"
+    "add-page": "node scripts/add-page.js",
+    "add-word": "node scripts/add-word.js"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.12",

--- a/scripts/add-word.js
+++ b/scripts/add-word.js
@@ -1,0 +1,139 @@
+import welcome from "cli-welcome";
+import inquirer from "inquirer";
+import chalk from "chalk";
+import fs from "fs";
+import path from "path";
+
+const question = chalk.hex("#fbbf24");
+const success = chalk.green;
+const error = chalk.red;
+
+welcome({
+  title: `Word of the Day CLI`,
+  tagLine: `by @p3yman`,
+  bgColor: `#1755f6`,
+  color: `#ffffff`,
+  bold: true,
+  clear: true,
+  version: `0.1.0`,
+});
+
+const wordsFilePath = path.join(
+  process.cwd(),
+  "src/content/word-of-the-day/words.json"
+);
+
+// Load existing words
+let wordsData = {};
+try {
+  const existingData = fs.readFileSync(wordsFilePath, "utf8");
+  wordsData = JSON.parse(existingData);
+} catch (err) {
+  console.log(
+    chalk.yellow("⚠ No existing words file found, creating new one")
+  );
+}
+
+// Get tomorrow's date as default
+const tomorrow = new Date();
+tomorrow.setDate(tomorrow.getDate() + 1);
+const defaultDate = tomorrow.toISOString().split("T")[0];
+
+inquirer
+  .prompt([
+    {
+      type: "input",
+      name: "date",
+      message: question(`Date for this word (YYYY-MM-DD):`),
+      default: defaultDate,
+      validate: (input) => {
+        const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+        if (!dateRegex.test(input)) {
+          return "Please enter date in YYYY-MM-DD format";
+        }
+
+        const date = new Date(input);
+        if (isNaN(date.getTime())) {
+          return "Please enter a valid date";
+        }
+
+        if (wordsData[input]) {
+          return `A word already exists for ${input}. Choose a different date.`;
+        }
+
+        return true;
+      },
+    },
+    {
+      type: "input",
+      name: "word",
+      message: question("What is the word?"),
+      validate: (input) => {
+        if (!input.trim().length) {
+          return "Please provide a word";
+        }
+        return true;
+      },
+    },
+    {
+      type: "input",
+      name: "pronunciation",
+      message: question("How is it pronounced? (e.g., /prəˌnʌnsiˈeɪʃən/)"),
+      validate: (input) => {
+        if (!input.trim().length) {
+          return "Please provide pronunciation";
+        }
+        return true;
+      },
+    },
+    {
+      type: "input",
+      name: "meaning",
+      message: question("What does it mean?"),
+      validate: (input) => {
+        if (!input.trim().length) {
+          return "Please provide the meaning";
+        }
+        return true;
+      },
+    },
+    {
+      type: "input",
+      name: "context",
+      message: question("Where did you hear/find this word? (optional)"),
+    },
+  ])
+  .then((answers) => {
+    // Add the new word
+    wordsData[answers.date] = {
+      word: answers.word.trim(),
+      pronunciation: answers.pronunciation.trim(),
+      meaning: answers.meaning.trim(),
+      context: answers.context.trim() || undefined,
+    };
+
+    // Sort dates and create sorted object
+    const sortedDates = Object.keys(wordsData).sort();
+    const sortedWordsData = {};
+    sortedDates.forEach((date) => {
+      sortedWordsData[date] = wordsData[date];
+    });
+
+    // Write back to file
+    try {
+      fs.writeFileSync(wordsFilePath, JSON.stringify(sortedWordsData, null, 2));
+      console.log(
+        `\n${success("✔")} ${chalk.bold("Word added successfully!")}`
+      );
+      console.log(`${chalk.gray("Date:")} ${answers.date}`);
+      console.log(`${chalk.gray("Word:")} ${answers.word}`);
+      console.log(
+        `${chalk.gray("View at:")} /word-of-the-day/${answers.date}\n`
+      );
+    } catch (err) {
+      console.log(`\n${error("✗")} Failed to save word: ${err.message}\n`);
+    }
+  })
+  .catch((err) => {
+    console.log(`\n${error("✗")} Something went wrong: ${err.message}\n`);
+  });

--- a/src/components/WordCard.astro
+++ b/src/components/WordCard.astro
@@ -1,0 +1,97 @@
+---
+import ArrowLeft from "./icons/ArrowLeft.astro";
+import ArrowRight from "./icons/ArrowRight.astro";
+import { clsx } from "clsx";
+
+export interface Props {
+  word: string;
+  pronunciation: string;
+  meaning: string;
+  context?: string;
+  date: string;
+  prevDate?: string;
+  nextDate?: string;
+}
+
+const { word, pronunciation, meaning, date, prevDate, nextDate } =
+  Astro.props;
+
+const formatDate = (dateStr: string) => {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+};
+---
+
+<div class="flex items-center justify-center py-40">
+  <div class="max-w-2xl w-full">
+    <div class="text-center">
+      <p class="text-gray-400 text-sm font-light tracking-wider uppercase mb-2">
+        Word of the Day
+      </p>
+      <h1 class="text-gray-600 text-lg font-light">{formatDate(date)}</h1>
+    </div>
+
+    <hr class="my-8 border-gray-lighter" />
+
+    <div class="px-8 py-20 my-8">
+      <div class="flex flex-col justify-center items-center">
+        <h2
+          class="text-6xl md:text-7xl font-serif font-light text-gray-dark tracking-tight leading-none mb-6"
+        >
+          {word}
+        </h2>
+
+        <div>
+          <p class="text-gray-light text-xl font-light tracking-wide">
+            {pronunciation}
+          </p>
+        </div>
+
+        <div class="max-w-lg mx-auto mt-12">
+          <p class="text-gray text-lg leading-relaxed font-light">
+            "{meaning}"
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <hr class="my-8 border-gray-lighter" />
+
+    <div class="flex justify-between items-center">
+      <a
+        href={prevDate ? `/word-of-the-day/${prevDate}` : undefined}
+        class={clsx(
+          "flex items-center space-x-2 transition-colors duration-300",
+          prevDate
+            ? "group text-gray-dark hover:text-primary"
+            : "text-gray-light cursor-default"
+        )}
+      >
+        <ArrowLeft
+          class={clsx("size-4", prevDate && "transition-colors duration-300")}
+        />
+        <span class={"font-mono uppercase"}> Previous </span>
+      </a>
+
+      <a
+        href={nextDate ? `/word-of-the-day/${nextDate}` : undefined}
+        class={clsx(
+          "flex items-center space-x-2 transition-colors duration-300 group",
+          nextDate
+            ? "text-gray-dark hover:text-primary"
+            : "text-gray-light cursor-default"
+        )}
+      >
+        <span class={"font-mono uppercase"}> Next </span>
+        <ArrowRight
+          class={clsx("size-4", nextDate && "transition-colors duration-300")}
+        />
+      </a>
+    </div>
+  </div>
+</div>

--- a/src/components/icons/ArrowLeft.astro
+++ b/src/components/icons/ArrowLeft.astro
@@ -1,0 +1,26 @@
+---
+export interface Props {
+  class?: string;
+}
+
+const { class: className = "" } = Astro.props;
+---
+
+<svg
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  class={className}
+>
+  <g stroke-width="0" />
+  <g stroke-linecap="round" stroke-linejoin="round" />
+  <g>
+    <path
+      d="M20 12H4M4 12L10 6M4 12L10 18"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </g>
+</svg>

--- a/src/components/icons/ArrowRight.astro
+++ b/src/components/icons/ArrowRight.astro
@@ -1,0 +1,26 @@
+---
+export interface Props {
+  class?: string;
+}
+
+const { class: className = "" } = Astro.props;
+---
+
+<svg
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  class={className}
+>
+  <g stroke-width="0" />
+  <g stroke-linecap="round" stroke-linejoin="round" />
+  <g>
+    <path
+      d="M4 12H20M20 12L14 6M20 12L14 18"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </g>
+</svg>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -21,4 +21,14 @@ const blog = defineCollection({
     }),
 });
 
-export const collections = { blog };
+const wordOfTheDay = defineCollection({
+  loader: glob({ pattern: "words.json", base: "./src/content/word-of-the-day" }),
+  schema: z.record(z.string(), z.object({
+    word: z.string(),
+    pronunciation: z.string(),
+    meaning: z.string(),
+    context: z.string().optional(),
+  })),
+});
+
+export const collections = { blog, wordOfTheDay };

--- a/src/content/word-of-the-day/words.json
+++ b/src/content/word-of-the-day/words.json
@@ -1,0 +1,50 @@
+{
+  "2025-07-15": {
+    "word": "serendipity",
+    "pronunciation": "/ˌserənˈdipədē/",
+    "meaning": "The occurrence and development of events by chance in a happy or beneficial way",
+    "context": "Found this word in a conversation about unexpected career opportunities"
+  },
+  "2025-07-28": {
+    "word": "ephemeral",
+    "pronunciation": "/əˈfem(ə)rəl/",
+    "meaning": "Lasting for a very short time; transitory",
+    "context": "Teammate used this describing temporary cloud resources"
+  },
+  "2025-08-05": {
+    "word": "ubiquitous",
+    "pronunciation": "/yo͞oˈbikwədəs/",
+    "meaning": "Present, appearing, or found everywhere",
+    "context": "From a chat about how smartphones have become ubiquitous"
+  },
+  "2025-08-12": {
+    "word": "mellifluous",
+    "pronunciation": "/məˈliflo͞oəs/",
+    "meaning": "Sweet or musical; pleasant to hear",
+    "context": "Friend described a podcast host's voice as mellifluous"
+  },
+  "2025-08-18": {
+    "word": "perspicacious",
+    "pronunciation": "/ˌpərspəˈkāSHəs/",
+    "meaning": "Having a ready insight into and understanding of things",
+    "context": "Used in team discussion about a colleague's analytical skills"
+  },
+  "2025-08-23": {
+    "word": "quixotic",
+    "pronunciation": "/kwikˈsädik/",
+    "meaning": "Extremely idealistic; unrealistic and impractical",
+    "context": "Describing an overly ambitious startup idea in our group chat"
+  },
+  "2025-08-29": {
+    "word": "grandiloquent",
+    "pronunciation": "/granˈdiləkwənt/",
+    "meaning": "Pompous or extravagant in language, style, or manner",
+    "context": "Someone joked about a manager's grandiloquent presentation style"
+  },
+  "2025-08-30": {
+    "word": "inscrutable",
+    "pronunciation": "/inˈskro͞odəb(ə)l/",
+    "meaning": "Impossible to understand or interpret",
+    "context": "Friend used this to describe a cryptic error message in their code"
+  }
+}

--- a/src/pages/word-of-the-day/[date].astro
+++ b/src/pages/word-of-the-day/[date].astro
@@ -1,0 +1,57 @@
+---
+import { getCollection } from "astro:content";
+import WordCard from "../../components/WordCard.astro";
+import Default from "../../layouts/Default.astro";
+
+export async function getStaticPaths() {
+  const wordCollection = await getCollection("wordOfTheDay");
+  const wordsData = wordCollection[0]?.data || {};
+
+  return Object.keys(wordsData).map((date) => ({
+    params: { date },
+    props: {
+      word: wordsData[date],
+      date,
+      allDates: Object.keys(wordsData).sort(),
+    },
+  }));
+}
+
+const { date } = Astro.params;
+const { word, allDates } = Astro.props;
+
+// Validate date exists and is not in the future
+const today = new (globalThis.Date as DateConstructor)()
+  .toISOString()
+  .split("T")[0];
+if (!word) {
+  throw new Error(`No word found for date: ${date}`);
+}
+
+if (date > today) {
+  throw new Error(`Word for ${date} is not yet available`);
+}
+
+// Find previous and next available dates
+const currentIndex = allDates.indexOf(date);
+const prevDate = currentIndex > 0 ? allDates[currentIndex - 1] : undefined;
+const nextDate =
+  currentIndex < allDates.length - 1 && allDates[currentIndex + 1] <= today
+    ? allDates[currentIndex + 1]
+    : undefined;
+---
+
+<Default
+  title={`Word of the Day: ${word.word}`}
+  description={`${word.word} - ${word.meaning}`}
+>
+  <WordCard
+    word={word.word}
+    pronunciation={word.pronunciation}
+    meaning={word.meaning}
+    context={word.context}
+    date={date}
+    prevDate={prevDate}
+    nextDate={nextDate}
+  />
+</Default>

--- a/src/pages/word-of-the-day/index.astro
+++ b/src/pages/word-of-the-day/index.astro
@@ -1,0 +1,24 @@
+---
+import { getCollection } from "astro:content";
+
+// Get all words and find the closest one to today
+const wordCollection = await getCollection("wordOfTheDay");
+const wordsData = wordCollection[0]?.data || {};
+
+const today = new Date().toISOString().split("T")[0];
+const availableDates = Object.keys(wordsData).sort();
+
+// Find the closest word to today (today's word or most recent past word)
+let targetDate = today;
+const todayOrBefore = availableDates.filter((date) => date <= today);
+if (todayOrBefore.length > 0) {
+  targetDate = todayOrBefore[todayOrBefore.length - 1];
+} else {
+  // If no words for today or before, redirect to earliest available
+  targetDate = availableDates[0];
+}
+
+// Redirect to the target date
+return Astro.redirect(`/word-of-the-day/${targetDate}`);
+---
+


### PR DESCRIPTION
## Summary
- Add complete word-of-the-day feature with daily vocabulary learning
- Implement content collection system for managing vocabulary data
- Create interactive word card component with navigation
- Add CLI tool for easy word addition and content management

## Changes
- **Content System**: New `wordOfTheDay` collection in content config with JSON loader
- **UI Components**: WordCard component with pronunciation, meaning, and date navigation
- **Pages**: Index page (redirects to latest) and dynamic date-based routing
- **CLI Tool**: `npm run add-word` script for adding new vocabulary entries
- **Icons**: Arrow navigation components for previous/next word browsing

## Test plan
- [ ] Verify `/word-of-the-day/` redirects to latest available word
- [ ] Test navigation between different word dates
- [ ] Confirm CLI tool creates properly formatted JSON entries
- [ ] Check responsive design on mobile and desktop
- [ ] Validate date-based routing works correctly